### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/renovate-trigger.yml
+++ b/.github/workflows/renovate-trigger.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/YY-Nexus/YanYu-Cloud-Cube-App/security/code-scanning/3](https://github.com/YY-Nexus/YanYu-Cloud-Cube-App/security/code-scanning/3)

To fix the problem, explicitly set a `permissions` block in the workflow YAML file (`.github/workflows/renovate-trigger.yml`). The minimal required permissions should allow Renovate Bot to read repository contents and create pull requests if needed. This is typically `contents: read` (to fetch files) and `pull-requests: write` (to open/update pull requests). The block should be added at the workflow level (above `jobs:`), so that all jobs inherit the restricted permissions unless overridden. No other code changes, imports, or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
