### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]


### PR DESCRIPTION
Potential fix for [https://github.com/YY-Nexus/YanYu-Cloud-Cube-App/security/code-scanning/2](https://github.com/YY-Nexus/YanYu-Cloud-Cube-App/security/code-scanning/2)

To minimize the permissions granted to the GITHUB_TOKEN and adhere to the principle of least privilege, add a `permissions` block specifying `contents: read` to the workflow. This block can be added either at the root (recommended for single-job workflows) or at the job level. Based on the provided snippet, the best solution is to add a top-level `permissions: contents: read` line right after the workflow name and before `on:` (or after `on:` if strictly conforming to syntax). This ensures all jobs in the workflow default to read-only access unless otherwise specified and does not interfere with any existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
