### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,4 +1,6 @@
 name: Lighthouse CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/YY-Nexus/YanYu-Cloud-Cube-App/security/code-scanning/1](https://github.com/YY-Nexus/YanYu-Cloud-Cube-App/security/code-scanning/1)

To fix the issue, add a `permissions` block to specify the least privilege necessary for the workflow. Since the current workflow only checks out code and installs/runs dependencies, it doesn't appear to need more than `contents: read`. 

The best way to implement this is to add the following at the top level (root) of the workflow file, below the `name:` but above `on:`:

```yaml
permissions:
  contents: read
```

No imports or further configuration are needed, and no steps require write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
